### PR TITLE
Fix Windows-reserved output filenames

### DIFF
--- a/pastemd/utils/fs.py
+++ b/pastemd/utils/fs.py
@@ -177,12 +177,21 @@ def sanitize_filename(filename: str, max_length: int = 100) -> str:
     # 移除多个连续的下划线
     cleaned = re.sub(r'_+', '_', cleaned)
     
-    # 移除前后的下划线
-    cleaned = cleaned.strip('_')
+    # 移除前后的下划线，以及 Windows 不允许的尾随点和空格
+    cleaned = cleaned.strip('_').rstrip(' .')
     
     # 限制长度
     if len(cleaned) > max_length:
-        cleaned = cleaned[:max_length].rstrip('_')
+        cleaned = cleaned[:max_length].rstrip('_').rstrip(' .')
+
+    reserved_names = {
+        "CON", "PRN", "AUX", "NUL",
+        *(f"COM{i}" for i in range(1, 10)),
+        *(f"LPT{i}" for i in range(1, 10)),
+    }
+    stem, ext = os.path.splitext(cleaned)
+    if stem.upper() in reserved_names:
+        cleaned = f"{stem}_{ext}"
     
     return cleaned or "document"
 

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,0 +1,17 @@
+from pastemd.utils.fs import sanitize_filename
+
+
+def test_sanitize_filename_keeps_regular_names():
+    assert sanitize_filename("Chapter 1: Intro") == "Chapter 1_ Intro"
+
+
+def test_sanitize_filename_avoids_windows_reserved_names():
+    assert sanitize_filename("CON") == "CON_"
+    assert sanitize_filename("con") == "con_"
+    assert sanitize_filename("AUX.txt") == "AUX_.txt"
+    assert sanitize_filename("LPT9") == "LPT9_"
+
+
+def test_sanitize_filename_strips_trailing_dots_and_spaces():
+    assert sanitize_filename("report. ") == "report"
+    assert sanitize_filename("...") == "document"


### PR DESCRIPTION
## Summary
- Make `sanitize_filename()` avoid Windows reserved device names such as `CON`, `AUX`, `COM1`, and `LPT9`.
- Strip trailing dots and spaces, which Windows also rejects for filenames.
- Add focused regression tests for the filename sanitizer.

## Why
PasteMD derives output names from Markdown, HTML, and table content. If that content produces a title like `CON` or `AUX.txt`, Windows treats the basename as a reserved device name and file creation can fail even though the string no longer contains path separators or other invalid characters.

## Validation
- `/Users/ccw3/odysseus/venv/bin/python -m pytest tests/test_fs.py -q` (`3 passed`)
- `/Users/ccw3/odysseus/venv/bin/python -m compileall -q pastemd tests/test_fs.py main.py PasteMD.py`
- `git diff --check`