### PR TITLE
修复 Obsidian 复制内容中的数学公式粘贴问题

### DIFF
--- a/pastemd/integrations/pandoc.py
+++ b/pastemd/integrations/pandoc.py
@@ -157,7 +157,7 @@ class PandocIntegration:
         md = md.replace('\r\n', '\n').replace('\r', '\n')  # 统一换行符
         md = re.sub(r'```\s*math\s*\n(.*?)\n\s*```', r'$$\n\1\n$$', md, flags=re.DOTALL)
         md = re.sub(r'\$\s*`([^`]+)`\s*\$', r'$\1$', md)
-        md = re.sub(r'(```\s*\w+)\s+[^\n]+', r'\1', md)
+        md = re.sub(r'(^```\s*\w+)[^\S\n]+[^\n]+$', r'\1', md, flags=re.MULTILINE)
         # 处理\~~删除线文本\~~
         md = re.sub(r'\\~~(.*?)\\~~', r'~~\1~~', md)
 

--- a/pastemd/service/preprocessor/html.py
+++ b/pastemd/service/preprocessor/html.py
@@ -11,6 +11,26 @@ from ...utils.html_formatter import (
 from ...utils.logging import log
 
 
+OBSIDIAN_CLIPBOARD_MARKER = "<!-- obsidian -->"
+
+
+def _wrap_obsidian_math_latex(soup: BeautifulSoup, html: str) -> None:
+    """Restore LaTeX delimiters for Obsidian clipboard math nodes."""
+    if OBSIDIAN_CLIPBOARD_MARKER not in html:
+        return
+
+    for tag in soup.select("span.math.math-inline"):
+        text = tag.get_text()
+        if text and not text.strip().startswith("$"):
+            tag.string = f"${text}$"
+
+    for tag in soup.select("div.math.math-block"):
+        text = tag.get_text()
+        stripped = text.strip()
+        if stripped and not stripped.startswith("$$"):
+            tag.string = f"$${text}$$"
+
+
 class HtmlPreprocessor(BasePreprocessor):
     """HTML 内容预处理器（无状态）"""
 
@@ -35,6 +55,7 @@ class HtmlPreprocessor(BasePreprocessor):
 
         # 使用 html_formatter 进行清理
         soup = BeautifulSoup(html, "html.parser")
+        _wrap_obsidian_math_latex(soup, html)
         clean_html_content(soup, config)
 
         html_formatting = config.get("html_formatting") or config.get("Html_formatting") or {}


### PR DESCRIPTION
## 变更内容
- 使用精确的 `<!-- obsidian -->` 标记识别 Obsidian 剪贴板 HTML。
- 在 HTML 预处理阶段，为 Obsidian 的 `math-inline` 和 `math-block` 节点补回 LaTeX 分隔符。
- 修正 HTML 转 Markdown 后处理中的代码围栏清理逻辑，避免误删代码块第一行。

Refs #64