### PR TITLE
修复 Obsidian 单行块级公式粘贴问题

### DIFF
--- a/pastemd/service/preprocessor/html.py
+++ b/pastemd/service/preprocessor/html.py
@@ -20,15 +20,18 @@ def _wrap_obsidian_math_latex(soup: BeautifulSoup, html: str) -> None:
         return
 
     for tag in soup.select("span.math.math-inline"):
-        text = tag.get_text()
-        if text and not text.strip().startswith("$"):
-            tag.string = f"${text}$"
+        text = tag.get_text().strip()
+        if not text:
+            continue
+        latex = text if text.startswith("$") else f"${text}$"
+        tag.replace_with(latex)
 
-    for tag in soup.select("div.math.math-block"):
-        text = tag.get_text()
-        stripped = text.strip()
-        if stripped and not stripped.startswith("$$"):
-            tag.string = f"$${text}$$"
+    for tag in soup.select(".math.math-block"):
+        text = tag.get_text().strip()
+        if not text:
+            continue
+        latex = text if text.startswith("$$") else f"$${text}$$"
+        tag.replace_with(latex)
 
 
 class HtmlPreprocessor(BasePreprocessor):


### PR DESCRIPTION
## 变更内容
- 修复 Obsidian 单行块级公式 `$$...$$` 复制后生成 `span.math-block` 时无法正确转换的问题。
- 将 Obsidian 的 math 节点整体替换为 LaTeX 文本，避免残留 `</span>` 干扰 Pandoc 解析。
- 继续使用 `<!-- obsidian -->` 标记限定影响范围。

Refs #64