### PR TITLE
修复 Markdown 与 HTML 单换行粘贴到 Word 的保留问题

### DIFF
--- a/pastemd/config/defaults.py
+++ b/pastemd/config/defaults.py
@@ -68,6 +68,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "no_app_action": "open",  # 无应用检测时的动作：open=自动打开, save=仅保存, clipboard=复制到剪贴板, none=无操作
     "md_disable_first_para_indent": True,
     "html_disable_first_para_indent": True,
+    "markdown_hard_line_breaks": False,
     "horizontal_rule_style": "default",  # default=Pandoc 原生横线, paragraph_border=Office/WPS 段落边框线
     "html_formatting": {
         "strikethrough_to_del": True,

--- a/pastemd/i18n/locales/en-US.json
+++ b/pastemd/i18n/locales/en-US.json
@@ -146,6 +146,8 @@
     "settings.conversion.first_paragraph_heading": "Disable first-paragraph formatting",
     "settings.conversion.md_indent": "Markdown: disable special first-paragraph style after headings",
     "settings.conversion.html_indent": "HTML: disable special first-paragraph style after headings",
+    "settings.conversion.markdown_hard_line_breaks": "Markdown: preserve line breaks inside paragraphs",
+    "settings.conversion.markdown_hard_line_breaks_note": "Useful for quiz/options text that must stay line-by-line. When enabled, each single line break inside a paragraph is kept as a Word line break.",
     "settings.conversion.pandoc_filters": "Pandoc filters (per conversion)",
     "settings.conversion.pandoc_filters_note": "(applied top to bottom)",
     "settings.conversion.filter_conversion_label": "Conversion",

--- a/pastemd/i18n/locales/ja-JP.json
+++ b/pastemd/i18n/locales/ja-JP.json
@@ -146,6 +146,8 @@
     "settings.conversion.first_paragraph_heading": "先頭段落の書式を無効化する",
     "settings.conversion.md_indent": "Markdown：見出し後の先頭段落の特殊書式を無効化",
     "settings.conversion.html_indent": "HTML：見出し後の先頭段落の特殊書式を無効化",
+    "settings.conversion.markdown_hard_line_breaks": "Markdown：段落内の単独改行を保持",
+    "settings.conversion.markdown_hard_line_breaks_note": "選択肢など行ごとに保持したい内容向けです。有効にすると、段落内の単独改行を Word の改行として保持します。",
     "settings.conversion.pandoc_filters": "Pandoc Filters（変換ごと）",
     "settings.conversion.pandoc_filters_note": "（該当の変換で上から順に適用）",
     "settings.conversion.filter_conversion_label": "変換タイプ",

--- a/pastemd/i18n/locales/zh-CN.json
+++ b/pastemd/i18n/locales/zh-CN.json
@@ -146,6 +146,8 @@
     "settings.conversion.first_paragraph_heading": "是否禁用首段格式",
     "settings.conversion.md_indent": "Markdown：禁用标题后首段特殊格式",
     "settings.conversion.html_indent": "HTML：禁用标题后首段特殊格式",
+    "settings.conversion.markdown_hard_line_breaks": "Markdown：保留段落内单换行",
+    "settings.conversion.markdown_hard_line_breaks_note": "用于选择题等需要逐行保留的内容。开启后，段落内每个单换行都会在 Word 中保留为换行。",
     "settings.conversion.pandoc_filters": "Pandoc Filters（按转换类型）",
     "settings.conversion.pandoc_filters_note": "（该转换执行顺序从上到下）",
     "settings.conversion.filter_conversion_label": "转换类型",

--- a/pastemd/integrations/pandoc.py
+++ b/pastemd/integrations/pandoc.py
@@ -15,6 +15,14 @@ from ..utils.logging import log
 LUA_KEEP_ORIGINAL_FORMULA = resource_path("lua/keep-latex-math.lua")
 LUA_LATEX_REPLACEMENTS = resource_path("lua/latex-replacements.lua")
 LUA_NORMALIZE_MARKDOWN_BREAKS = resource_path("lua/normalize-markdown-breaks.lua")
+MARKDOWN_READER_EXTENSIONS = "+tex_math_dollars+raw_tex+tex_math_double_backslash+tex_math_single_backslash"
+
+
+def _markdown_input_format(*, hard_line_breaks: bool = False) -> str:
+    extensions = MARKDOWN_READER_EXTENSIONS
+    if hard_line_breaks:
+        extensions = "+hard_line_breaks" + extensions
+    return "markdown" + extensions
 
 
 def _log_pandoc_stderr_as_warning(stderr: Optional[bytes], *, context: str) -> None:
@@ -181,6 +189,7 @@ class PandocIntegration:
         *,
         Keep_original_formula: bool = False,
         enable_latex_replacements: bool = True,
+        markdown_hard_line_breaks: bool = False,
         custom_filters: Optional[List[str]] = None,
         cwd: Optional[str] = None,
     ) -> str:
@@ -193,7 +202,7 @@ class PandocIntegration:
         """
         cmd = [
             self.pandoc_path,
-            "-f", "markdown+tex_math_dollars+raw_tex+tex_math_double_backslash+tex_math_single_backslash",
+            "-f", _markdown_input_format(hard_line_breaks=markdown_hard_line_breaks),
             "-t", "html",
             "-o", "-",
             "--wrap", "none",
@@ -242,6 +251,7 @@ class PandocIntegration:
         *,
         Keep_original_formula: bool = False,
         enable_latex_replacements: bool = True,
+        markdown_hard_line_breaks: bool = False,
         custom_filters: Optional[List[str]] = None,
         request_headers: Optional[List[str]] = None,
         cwd: Optional[str] = None,
@@ -251,7 +261,7 @@ class PandocIntegration:
         """
         cmd = [
             self.pandoc_path,
-            "-f", "markdown+tex_math_dollars+raw_tex+tex_math_double_backslash+tex_math_single_backslash",
+            "-f", _markdown_input_format(hard_line_breaks=markdown_hard_line_breaks),
             "-t", "rtf",
             "-o", "-",
             "--standalone",
@@ -293,7 +303,7 @@ class PandocIntegration:
 
         return result.stdout
 
-    def convert_to_docx_bytes(self, md_text: str, reference_docx: Optional[str] = None, Keep_original_formula: bool = False, enable_latex_replacements: bool = True, custom_filters: Optional[List[str]] = None, request_headers: Optional[List[str]] = None, cwd: Optional[str] = None) -> bytes:
+    def convert_to_docx_bytes(self, md_text: str, reference_docx: Optional[str] = None, Keep_original_formula: bool = False, enable_latex_replacements: bool = True, markdown_hard_line_breaks: bool = False, custom_filters: Optional[List[str]] = None, request_headers: Optional[List[str]] = None, cwd: Optional[str] = None) -> bytes:
         """
         用 stdin 喂入 Markdown，直接把 DOCX 从 stdout 读到内存（无任何输入文件写盘）
         
@@ -310,7 +320,7 @@ class PandocIntegration:
         """
         cmd = [
             self.pandoc_path,
-            "-f", "markdown+tex_math_dollars+raw_tex+tex_math_double_backslash+tex_math_single_backslash",
+            "-f", _markdown_input_format(hard_line_breaks=markdown_hard_line_breaks),
             "-t", "docx",
             "-o", "-",
             "--highlight-style", "tango",
@@ -529,6 +539,7 @@ class PandocIntegration:
         *,
         strip_preamble: bool = True,
         enable_latex_replacements: bool = True,
+        markdown_hard_line_breaks: bool = False,
         custom_filters: Optional[List[str]] = None,
     ) -> str:
         """
@@ -545,7 +556,7 @@ class PandocIntegration:
         """
         cmd = [
             self.pandoc_path,
-            "-f", "markdown+tex_math_dollars+raw_tex+tex_math_double_backslash+tex_math_single_backslash",
+            "-f", _markdown_input_format(hard_line_breaks=markdown_hard_line_breaks),
             "-t", "latex",
             "-o", "-",
             "--wrap", "none",

--- a/pastemd/presentation/settings/dialog.py
+++ b/pastemd/presentation/settings/dialog.py
@@ -614,6 +614,19 @@ class SettingsDialog:
         self.html_indent_var = tk.BooleanVar(value=self.current_config.get("html_disable_first_para_indent", True))
         ttk.Checkbutton(content, text=t("settings.conversion.html_indent"), variable=self.html_indent_var).grid(row=current_row+5, column=0, columnspan=3, sticky=tk.W, pady=2)
 
+        self.markdown_hard_line_breaks_var = tk.BooleanVar(value=self.current_config.get("markdown_hard_line_breaks", False))
+        ttk.Checkbutton(
+            content,
+            text=t("settings.conversion.markdown_hard_line_breaks"),
+            variable=self.markdown_hard_line_breaks_var,
+        ).grid(row=current_row+6, column=0, columnspan=3, sticky=tk.W, pady=(8, 2))
+        ttk.Label(
+            content,
+            text=t("settings.conversion.markdown_hard_line_breaks_note"),
+            foreground="gray",
+            font=("", 8),
+        ).grid(row=current_row+7, column=0, columnspan=3, sticky=tk.W, padx=(20, 0), pady=(0, 5))
+
     def _create_advanced_tab(self):
         """创建高级设置选项卡"""
         frame = ttk.Frame(self.notebook, padding=10)
@@ -928,6 +941,10 @@ class SettingsDialog:
             new_config["html_disable_first_para_indent"] = self._get_var_value(
                 "html_indent_var",
                 self.current_config.get("html_disable_first_para_indent", True),
+            )
+            new_config["markdown_hard_line_breaks"] = self._get_var_value(
+                "markdown_hard_line_breaks_var",
+                self.current_config.get("markdown_hard_line_breaks", False),
             )
             new_config["Keep_original_formula"] = self._get_var_value(
                 "keep_formula_var",

--- a/pastemd/service/document/generator.py
+++ b/pastemd/service/document/generator.py
@@ -191,6 +191,7 @@ class DocumentGenerator:
             reference_docx=config.get("reference_docx"),
             Keep_original_formula=config.get("Keep_original_formula", False),
             enable_latex_replacements=config.get("enable_latex_replacements", True),
+            markdown_hard_line_breaks=config.get("markdown_hard_line_breaks", False),
             custom_filters=_get_pandoc_filters(config, "md_to_docx"),
             request_headers=request_headers,
             cwd=config.get("save_dir"),
@@ -286,6 +287,7 @@ class DocumentGenerator:
             md_text,
             Keep_original_formula=config.get("Keep_original_formula", True),
             enable_latex_replacements=config.get("enable_latex_replacements", True),
+            markdown_hard_line_breaks=config.get("markdown_hard_line_breaks", False),
             custom_filters=_get_pandoc_filters(config, "md_to_html"),
             cwd=config.get("save_dir"),
         )
@@ -304,6 +306,7 @@ class DocumentGenerator:
             md_text,
             Keep_original_formula=config.get("Keep_original_formula", True),
             enable_latex_replacements=config.get("enable_latex_replacements", True),
+            markdown_hard_line_breaks=config.get("markdown_hard_line_breaks", False),
             custom_filters=_get_pandoc_filters(config, "md_to_rtf"),
             request_headers=request_headers,
             cwd=config.get("save_dir"),
@@ -336,5 +339,6 @@ class DocumentGenerator:
             md_text,
             strip_preamble=True,
             enable_latex_replacements=config.get("enable_latex_replacements", True),
+            markdown_hard_line_breaks=config.get("markdown_hard_line_breaks", False),
             custom_filters=_get_pandoc_filters(config, "md_to_latex"),
         )

--- a/pastemd/service/preprocessor/html.py
+++ b/pastemd/service/preprocessor/html.py
@@ -1,6 +1,8 @@
 """HTML content preprocessor."""
 
-from bs4 import BeautifulSoup
+import re
+
+from bs4 import BeautifulSoup, NavigableString, Tag
 from .base import BasePreprocessor
 from ...utils.html_formatter import (
     clean_html_content,
@@ -12,6 +14,11 @@ from ...utils.logging import log
 
 
 OBSIDIAN_CLIPBOARD_MARKER = "<!-- obsidian -->"
+PRESERVE_NEWLINE_WHITE_SPACE_RE = re.compile(
+    r"(?:^|;)\s*white-space\s*:\s*(?:pre-wrap|pre-line|break-spaces)\b",
+    re.IGNORECASE,
+)
+NEWLINE_EXCLUDED_TAGS = {"script", "style", "textarea", "pre", "code"}
 
 
 def _wrap_obsidian_math_latex(soup: BeautifulSoup, html: str) -> None:
@@ -32,6 +39,34 @@ def _wrap_obsidian_math_latex(soup: BeautifulSoup, html: str) -> None:
             continue
         latex = text if text.startswith("$$") else f"$${text}$$"
         tag.replace_with(latex)
+
+
+def _convert_preserved_newlines_to_br(soup: BeautifulSoup) -> None:
+    """Make CSS-preserved text newlines explicit before Pandoc consumes HTML."""
+    for tag in soup.find_all(style=PRESERVE_NEWLINE_WHITE_SPACE_RE):
+        if not isinstance(tag, Tag):
+            continue
+        for text_node in list(tag.find_all(string=True)):
+            parent = text_node.parent
+            if not parent or any(
+                ancestor.name and ancestor.name.lower() in NEWLINE_EXCLUDED_TAGS
+                for ancestor in text_node.parents
+            ):
+                continue
+
+            text = str(text_node).replace("\r\n", "\n").replace("\r", "\n")
+            if "\n" not in text:
+                continue
+
+            replacement = []
+            parts = text.split("\n")
+            for index, part in enumerate(parts):
+                if part:
+                    replacement.append(NavigableString(part))
+                if index < len(parts) - 1:
+                    replacement.append(soup.new_tag("br"))
+
+            text_node.replace_with(*replacement)
 
 
 class HtmlPreprocessor(BasePreprocessor):
@@ -60,6 +95,7 @@ class HtmlPreprocessor(BasePreprocessor):
         soup = BeautifulSoup(html, "html.parser")
         _wrap_obsidian_math_latex(soup, html)
         clean_html_content(soup, config)
+        _convert_preserved_newlines_to_br(soup)
 
         html_formatting = config.get("html_formatting") or config.get("Html_formatting") or {}
         if not isinstance(html_formatting, dict):


### PR DESCRIPTION
## 变更内容

- 修复 HTML 片段中 `white-space: pre-wrap/pre-line/break-spaces` 的段落换行丢失问题
- 新增 Markdown「保留段落内单换行」设置开关，默认关闭
- 开启该设置后，Pandoc Markdown reader 会启用 `hard_line_breaks`，让段落内单换行在 Word 中保留为硬换行
- 补充中英文日文设置文案

## 背景原因

部分来源复制出的 HTML 会把多行文本放在同一个带 `white-space: pre-wrap` 的 `<p>` 中。浏览器能按 CSS 显示换行，但 Pandoc 转 DOCX 时不会把文本节点里的 `\n` 写成 Word 硬换行，导致选项被合并成一行。

纯 Markdown 路径里，段落内单换行会被 Pandoc 按 Markdown 规范解析为 `SoftBreak`，写入 Word 时表现为空格。因此增加一个可配置开关，用于选择题、选项文本等需要逐行保留的场景。