### PR TITLE
增加实验性 DOCX 表格自动排版

### DIFF
--- a/pastemd/config/defaults.py
+++ b/pastemd/config/defaults.py
@@ -70,6 +70,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "html_disable_first_para_indent": True,
     "markdown_hard_line_breaks": False,
     "horizontal_rule_style": "default",  # default=Pandoc 原生横线, paragraph_border=Office/WPS 段落边框线
+    "docx_auto_table_layout": False,  # 实验性：根据内容自动调整 Word/WPS 表格列宽
     "html_formatting": {
         "strikethrough_to_del": True,
     },

--- a/pastemd/i18n/locales/en-US.json
+++ b/pastemd/i18n/locales/en-US.json
@@ -172,6 +172,8 @@
     "settings.conversion.latex_replacements_note": "(e.g., replace {\\kern 10pt} with \\qquad)",
     "settings.conversion.fix_single_dollar_block": "Auto-detect non-standard math blocks",
     "settings.conversion.fix_single_dollar_block_note": "(Convert single-line $ ... $ to $$ ... $$)",
+    "settings.conversion.docx_auto_table_layout": "Auto-adjust Word/WPS table column widths",
+    "settings.conversion.docx_auto_table_layout_note": "Experimental. Redistributes column widths based on table content, useful for short labels on the left and long content on the right.",
     "settings.conversion.pandoc_request_headers": "Pandoc request headers",
     "settings.conversion.pandoc_request_headers_enable": "Enable custom request headers (--request-header)",
     "settings.conversion.pandoc_request_headers_note": "One header per line, format: Name: Value. Useful for 403 image fetches (User-Agent/Referer).",

--- a/pastemd/i18n/locales/ja-JP.json
+++ b/pastemd/i18n/locales/ja-JP.json
@@ -172,6 +172,8 @@
     "settings.conversion.latex_replacements_note": "（例：{\\kern 10pt} を \\qquad に置換）",
     "settings.conversion.fix_single_dollar_block": "非標準のブロック数式を自動検出",
     "settings.conversion.fix_single_dollar_block_note": "（単独行の $ ... $ を $$ ... $$ に変換）",
+    "settings.conversion.docx_auto_table_layout": "Word/WPS 表の列幅を自動調整",
+    "settings.conversion.docx_auto_table_layout_note": "実験的機能。表の内容に基づいて列幅を再配分します。左に短いラベル、右に長い内容がある表に向いています。",
     "settings.conversion.pandoc_request_headers": "Pandoc request headers（リクエストヘッダー）",
     "settings.conversion.pandoc_request_headers_enable": "カスタム request headers（--request-header）を有効化",
     "settings.conversion.pandoc_request_headers_note": "1行に1ヘッダー、形式：Name: Value。画像リンクの 403（User-Agent/Referer が必要な場合など）対策。",

--- a/pastemd/i18n/locales/zh-CN.json
+++ b/pastemd/i18n/locales/zh-CN.json
@@ -172,6 +172,8 @@
     "settings.conversion.latex_replacements_note": "（例如：将 {\\kern 10pt} 替换为 \\qquad）",
     "settings.conversion.fix_single_dollar_block": "自动识别非标准块级公式",
     "settings.conversion.fix_single_dollar_block_note": "（将单独一行的 $ ... $ 转换为 $$ ... $$）",
+    "settings.conversion.docx_auto_table_layout": "自动调整 Word/WPS 表格列宽",
+    "settings.conversion.docx_auto_table_layout_note": "实验性功能。根据表格内容重新分配列宽，适合左侧短标签、右侧长内容的表格。",
     "settings.conversion.pandoc_request_headers": "Pandoc request headers（请求头）",
     "settings.conversion.pandoc_request_headers_enable": "启用自定义 request headers（--request-header）",
     "settings.conversion.pandoc_request_headers_note": "每行一个 header，格式：Name: Value。用于解决部分图片链接下载 403（如需要 User-Agent/Referer）。",

--- a/pastemd/presentation/settings/dialog.py
+++ b/pastemd/presentation/settings/dialog.py
@@ -684,6 +684,20 @@ class SettingsDialog:
         fix_dollar_label = ttk.Label(frame, text=fix_dollar_note, foreground="gray", font=("", 8))
         fix_dollar_label.grid(row=4, column=0, sticky=tk.W, padx=(20, 0), pady=(0, 5))
 
+        self.docx_auto_table_layout_var = tk.BooleanVar(value=self.current_config.get("docx_auto_table_layout", False))
+        ttk.Checkbutton(
+            frame,
+            text=t("settings.conversion.docx_auto_table_layout"),
+            variable=self.docx_auto_table_layout_var,
+        ).grid(row=5, column=0, sticky=tk.W, pady=5)
+
+        ttk.Label(
+            frame,
+            text=t("settings.conversion.docx_auto_table_layout_note"),
+            foreground="gray",
+            font=("", 8),
+        ).grid(row=6, column=0, sticky=tk.W, padx=(20, 0), pady=(0, 5))
+
         # Pandoc request headers（用于下载远程图片等资源时附加请求头）
         self._pandoc_request_headers_example = [
             "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
@@ -702,20 +716,20 @@ class SettingsDialog:
             frame,
             text=t("settings.conversion.pandoc_request_headers"),
             font=("", 10, "bold"),
-        ).grid(row=5, column=0, sticky=tk.W, pady=(10, 5))
+        ).grid(row=7, column=0, sticky=tk.W, pady=(10, 5))
 
         ttk.Checkbutton(
             frame,
             text=t("settings.conversion.pandoc_request_headers_enable"),
             variable=self.pandoc_request_headers_enable_var,
             command=self._toggle_pandoc_request_headers_state,
-        ).grid(row=6, column=0, sticky=tk.W, pady=2)
+        ).grid(row=8, column=0, sticky=tk.W, pady=2)
 
         if not initial_headers:
             initial_headers = self._pandoc_request_headers_example
 
         headers_frame = ttk.Frame(frame)
-        headers_frame.grid(row=7, column=0, sticky=tk.EW, padx=(20, 0), pady=(0, 5))
+        headers_frame.grid(row=9, column=0, sticky=tk.EW, padx=(20, 0), pady=(0, 5))
         headers_frame.columnconfigure(0, weight=1)
 
         self.pandoc_request_headers_text = tk.Text(headers_frame, height=4, wrap="word")
@@ -735,13 +749,13 @@ class SettingsDialog:
             text=t("settings.conversion.pandoc_request_headers_note"),
             foreground="gray",
             font=("", 8),
-        ).grid(row=8, column=0, sticky=tk.W, padx=(20, 0), pady=(0, 5))
+        ).grid(row=10, column=0, sticky=tk.W, padx=(20, 0), pady=(0, 5))
 
         ttk.Button(
             frame,
             text=t("settings.conversion.pandoc_request_headers_fill_example"),
             command=self._fill_pandoc_request_headers_example,
-        ).grid(row=9, column=0, sticky=tk.W, padx=(20, 0), pady=(0, 5))
+        ).grid(row=11, column=0, sticky=tk.W, padx=(20, 0), pady=(0, 5))
 
     def _set_pandoc_request_headers_text(self, headers: list[str]) -> None:
         try:
@@ -957,6 +971,10 @@ class SettingsDialog:
             new_config["fix_single_dollar_block"] = self._get_var_value(
                 "fix_single_dollar_block_var",
                 self.current_config.get("fix_single_dollar_block", True),
+            )
+            new_config["docx_auto_table_layout"] = self._get_var_value(
+                "docx_auto_table_layout_var",
+                self.current_config.get("docx_auto_table_layout", False),
             )
 
             # pandoc_request_headers（实验性功能）

--- a/pastemd/service/document/generator.py
+++ b/pastemd/service/document/generator.py
@@ -204,11 +204,16 @@ class DocumentGenerator:
                 disable_first_para_indent=True,
                 target_style="Body Text",
                 horizontal_rule_style=config.get("horizontal_rule_style", "default"),
+                auto_layout_tables=config.get("docx_auto_table_layout", False),
             )
-        elif config.get("horizontal_rule_style") == "paragraph_border":
+        elif (
+            config.get("horizontal_rule_style") == "paragraph_border"
+            or config.get("docx_auto_table_layout", False)
+        ):
             docx_bytes = DocxProcessor.apply_custom_processing(
                 docx_bytes,
-                horizontal_rule_style="paragraph_border",
+                horizontal_rule_style=config.get("horizontal_rule_style", "default"),
+                auto_layout_tables=config.get("docx_auto_table_layout", False),
             )
         
         return docx_bytes
@@ -253,11 +258,16 @@ class DocumentGenerator:
                 disable_first_para_indent=True,
                 target_style="Body Text",
                 horizontal_rule_style=config.get("horizontal_rule_style", "default"),
+                auto_layout_tables=config.get("docx_auto_table_layout", False),
             )
-        elif config.get("horizontal_rule_style") == "paragraph_border":
+        elif (
+            config.get("horizontal_rule_style") == "paragraph_border"
+            or config.get("docx_auto_table_layout", False)
+        ):
             docx_bytes = DocxProcessor.apply_custom_processing(
                 docx_bytes,
-                horizontal_rule_style="paragraph_border",
+                horizontal_rule_style=config.get("horizontal_rule_style", "default"),
+                auto_layout_tables=config.get("docx_auto_table_layout", False),
             )
         
         return docx_bytes

--- a/pastemd/utils/docx_processor.py
+++ b/pastemd/utils/docx_processor.py
@@ -2,6 +2,7 @@
 
 import io
 import zipfile
+from xml.sax.saxutils import quoteattr
 from xml.etree import ElementTree as ET
 
 from docx import Document
@@ -9,6 +10,7 @@ from ..utils.logging import log
 
 
 _WORD_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+_MARKUP_COMPATIBILITY_NS = "http://schemas.openxmlformats.org/markup-compatibility/2006"
 _DOCX_TABLE_WIDTH_TWIPS = 9360
 _MIN_TABLE_COLUMN_TWIPS = 900
 _MAX_LABEL_COLUMN_TWIPS = 2200
@@ -97,6 +99,8 @@ class DocxProcessor:
 
             with zipfile.ZipFile(input_stream, "r") as zin:
                 document_xml = zin.read(document_path)
+                xml_namespaces = DocxProcessor._extract_xml_namespaces(document_xml)
+                DocxProcessor._register_xml_namespaces(xml_namespaces)
                 root = ET.fromstring(document_xml)
 
                 modified_count = 0
@@ -123,6 +127,11 @@ class DocxProcessor:
                     return docx_bytes
 
                 updated_document_xml = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+                updated_document_xml = DocxProcessor._preserve_ignorable_namespaces(
+                    updated_document_xml,
+                    root,
+                    xml_namespaces,
+                )
 
                 with zipfile.ZipFile(output_stream, "w") as zout:
                     for item in zin.infolist():
@@ -159,6 +168,8 @@ class DocxProcessor:
 
             with zipfile.ZipFile(input_stream, "r") as zin:
                 document_xml = zin.read(document_path)
+                xml_namespaces = DocxProcessor._extract_xml_namespaces(document_xml)
+                DocxProcessor._register_xml_namespaces(xml_namespaces)
                 root = ET.fromstring(document_xml)
 
                 modified_count = 0
@@ -174,6 +185,11 @@ class DocxProcessor:
                     return docx_bytes
 
                 updated_document_xml = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+                updated_document_xml = DocxProcessor._preserve_ignorable_namespaces(
+                    updated_document_xml,
+                    root,
+                    xml_namespaces,
+                )
 
                 with zipfile.ZipFile(output_stream, "w") as zout:
                     for item in zin.infolist():
@@ -187,6 +203,65 @@ class DocxProcessor:
         except Exception as e:
             log(f"Failed to auto-layout DOCX tables: {type(e).__name__}: {e}")
             return docx_bytes
+
+    @staticmethod
+    def _extract_xml_namespaces(xml_bytes: bytes) -> dict[str, str]:
+        namespaces: dict[str, str] = {}
+        try:
+            for _event, namespace in ET.iterparse(
+                io.BytesIO(xml_bytes),
+                events=("start-ns",),
+            ):
+                prefix, uri = namespace
+                if prefix and prefix not in namespaces:
+                    namespaces[prefix] = uri
+        except Exception as e:
+            log(f"Failed to extract DOCX XML namespaces: {type(e).__name__}: {e}")
+        return namespaces
+
+    @staticmethod
+    def _register_xml_namespaces(namespaces: dict[str, str]) -> None:
+        for prefix, uri in namespaces.items():
+            if prefix in ("xml", "xmlns"):
+                continue
+            try:
+                ET.register_namespace(prefix, uri)
+            except ValueError as e:
+                log(f"Failed to register DOCX XML namespace {prefix}: {e}")
+
+    @staticmethod
+    def _preserve_ignorable_namespaces(
+        xml_bytes: bytes,
+        root: ET.Element,
+        namespaces: dict[str, str],
+    ) -> bytes:
+        ignorable = root.get(f"{{{_MARKUP_COMPATIBILITY_NS}}}Ignorable")
+        if not ignorable:
+            return xml_bytes
+
+        xml_text = xml_bytes.decode("utf-8")
+        root_start = xml_text.find(":document")
+        if root_start < 0:
+            return xml_bytes
+        root_start = xml_text.rfind("<", 0, root_start)
+        if root_start < 0:
+            return xml_bytes
+        root_end = xml_text.find(">", root_start)
+        if root_end < 0:
+            return xml_bytes
+
+        root_tag = xml_text[root_start:root_end]
+        additions = []
+        for prefix in ignorable.split():
+            uri = namespaces.get(prefix)
+            if uri and f"xmlns:{prefix}=" not in root_tag:
+                additions.append(f" xmlns:{prefix}={quoteattr(uri)}")
+
+        if not additions:
+            return xml_bytes
+
+        xml_text = xml_text[:root_end] + "".join(additions) + xml_text[root_end:]
+        return xml_text.encode("utf-8")
 
     @staticmethod
     def _suggest_table_column_widths(table: ET.Element, namespaces: dict) -> list[int]:

--- a/pastemd/utils/docx_processor.py
+++ b/pastemd/utils/docx_processor.py
@@ -181,7 +181,7 @@ class DocxProcessor:
                     modified_count += 1
 
                 if modified_count == 0:
-                    log("No DOCX table found for auto layout")
+                    log("No eligible DOCX table found for auto layout")
                     return docx_bytes
 
                 updated_document_xml = ET.tostring(root, encoding="utf-8", xml_declaration=True)

--- a/pastemd/utils/docx_processor.py
+++ b/pastemd/utils/docx_processor.py
@@ -294,10 +294,15 @@ class DocxProcessor:
         available_width: int,
     ) -> int:
         modified_count = 0
-        widths = DocxProcessor._suggest_table_column_widths(
+        table_width = DocxProcessor._available_table_width(
             table,
             namespaces,
             available_width,
+        )
+        widths = DocxProcessor._suggest_table_column_widths(
+            table,
+            namespaces,
+            table_width,
         )
 
         if widths:
@@ -313,7 +318,7 @@ class DocxProcessor:
                 if cell_width is None and index < len(widths):
                     cell_width = widths[index]
                 if cell_width is None:
-                    cell_width = available_width
+                    cell_width = table_width
                 modified_count += DocxProcessor._auto_layout_tables_in_element(
                     cell,
                     namespaces,
@@ -352,6 +357,30 @@ class DocxProcessor:
             return []
 
         return DocxProcessor._column_widths_from_scores(scores, total_width)
+
+    @staticmethod
+    def _available_table_width(
+        table: ET.Element,
+        namespaces: dict,
+        fallback_width: int,
+    ) -> int:
+        tbl_width = table.find("./w:tblPr/w:tblW", namespaces)
+        if tbl_width is not None:
+            parsed_width = DocxProcessor._parse_twips(tbl_width.get(f"{{{_WORD_NS}}}w"))
+            if parsed_width is not None:
+                width_type = tbl_width.get(f"{{{_WORD_NS}}}type")
+                if width_type == "dxa":
+                    return parsed_width
+                if width_type == "pct":
+                    return max(1, int(fallback_width * parsed_width / 5000))
+
+        tbl_layout = table.find("./w:tblPr/w:tblLayout", namespaces)
+        if tbl_layout is not None and tbl_layout.get(f"{{{_WORD_NS}}}type") == "fixed":
+            grid_widths = DocxProcessor._existing_table_column_widths(table, namespaces)
+            if grid_widths:
+                return sum(grid_widths)
+
+        return fallback_width
 
     @staticmethod
     def _existing_table_column_widths(table: ET.Element, namespaces: dict) -> list[int]:
@@ -474,15 +503,12 @@ class DocxProcessor:
             tbl_pr = ET.Element(f"{w}tblPr")
             table.insert(0, tbl_pr)
 
-        tbl_w = tbl_pr.find("./w:tblW", namespaces)
-        if tbl_w is None:
-            tbl_w = ET.SubElement(tbl_pr, f"{w}tblW")
-        tbl_w.set(f"{w}type", "dxa")
-        tbl_w.set(f"{w}w", str(sum(widths)))
+        tbl_w = DocxProcessor._ensure_table_width_element(tbl_pr)
+        if tbl_w.get(f"{w}type") != "pct":
+            tbl_w.set(f"{w}type", "dxa")
+            tbl_w.set(f"{w}w", str(sum(widths)))
 
-        tbl_layout = tbl_pr.find("./w:tblLayout", namespaces)
-        if tbl_layout is None:
-            tbl_layout = ET.SubElement(tbl_pr, f"{w}tblLayout")
+        tbl_layout = DocxProcessor._ensure_table_layout_element(tbl_pr)
         tbl_layout.set(f"{w}type", "fixed")
 
         for child in list(table):
@@ -504,12 +530,96 @@ class DocxProcessor:
                 if tc_pr is None:
                     tc_pr = ET.Element(f"{w}tcPr")
                     cell.insert(0, tc_pr)
-                tc_w = tc_pr.find("./w:tcW", namespaces)
-                if tc_w is None:
-                    tc_w = ET.SubElement(tc_pr, f"{w}tcW")
+                tc_w = DocxProcessor._ensure_cell_width_element(tc_pr)
                 tc_w.set(f"{w}type", "dxa")
                 tc_w.set(f"{w}w", str(widths[index]))
-    
+
+    @staticmethod
+    def _ensure_table_width_element(tbl_pr: ET.Element) -> ET.Element:
+        w = f"{{{_WORD_NS}}}"
+        tbl_w = tbl_pr.find(f"./{w}tblW")
+        if tbl_w is not None:
+            return tbl_w
+
+        tbl_w = ET.Element(f"{w}tblW")
+        following_tags = {
+            f"{w}jc",
+            f"{w}tblCellSpacing",
+            f"{w}tblInd",
+            f"{w}tblBorders",
+            f"{w}shd",
+            f"{w}tblLayout",
+            f"{w}tblCellMar",
+            f"{w}tblLook",
+            f"{w}tblCaption",
+            f"{w}tblDescription",
+            f"{w}tblPrChange",
+        }
+        insert_index = len(tbl_pr)
+        for index, child in enumerate(list(tbl_pr)):
+            if child.tag in following_tags:
+                insert_index = index
+                break
+        tbl_pr.insert(insert_index, tbl_w)
+        return tbl_w
+
+    @staticmethod
+    def _ensure_table_layout_element(tbl_pr: ET.Element) -> ET.Element:
+        w = f"{{{_WORD_NS}}}"
+        tbl_layout = tbl_pr.find(f"./{w}tblLayout")
+        if tbl_layout is not None:
+            tbl_pr.remove(tbl_layout)
+        else:
+            tbl_layout = ET.Element(f"{w}tblLayout")
+
+        following_tags = {
+            f"{w}tblCellMar",
+            f"{w}tblLook",
+            f"{w}tblCaption",
+            f"{w}tblDescription",
+            f"{w}tblPrChange",
+        }
+        insert_index = len(tbl_pr)
+        for index, child in enumerate(list(tbl_pr)):
+            if child.tag in following_tags:
+                insert_index = index
+                break
+        tbl_pr.insert(insert_index, tbl_layout)
+        return tbl_layout
+
+    @staticmethod
+    def _ensure_cell_width_element(tc_pr: ET.Element) -> ET.Element:
+        w = f"{{{_WORD_NS}}}"
+        tc_w = tc_pr.find(f"./{w}tcW")
+        if tc_w is not None:
+            return tc_w
+
+        tc_w = ET.Element(f"{w}tcW")
+        following_tags = {
+            f"{w}gridSpan",
+            f"{w}hMerge",
+            f"{w}vMerge",
+            f"{w}tcBorders",
+            f"{w}shd",
+            f"{w}noWrap",
+            f"{w}tcMar",
+            f"{w}textDirection",
+            f"{w}tcFitText",
+            f"{w}vAlign",
+            f"{w}hideMark",
+            f"{w}cellIns",
+            f"{w}cellDel",
+            f"{w}cellMerge",
+            f"{w}tcPrChange",
+        }
+        insert_index = len(tc_pr)
+        for index, child in enumerate(list(tc_pr)):
+            if child.tag in following_tags:
+                insert_index = index
+                break
+        tc_pr.insert(insert_index, tc_w)
+        return tc_w
+     
     @staticmethod
     def apply_custom_processing(
         docx_bytes: bytes,

--- a/pastemd/utils/docx_processor.py
+++ b/pastemd/utils/docx_processor.py
@@ -427,7 +427,17 @@ class DocxProcessor:
         if len(weights) == 2 and weights[0] * 1.5 < weights[1]:
             first_share = weights[0] / sum(weights)
             first_width = int(total_width * max(0.14, min(first_share * 1.15, 0.24)))
-            first_width = max(_MIN_TABLE_COLUMN_TWIPS, min(first_width, _MAX_LABEL_COLUMN_TWIPS))
+            if total_width >= _MIN_TABLE_COLUMN_TWIPS * 2:
+                first_width = max(
+                    _MIN_TABLE_COLUMN_TWIPS,
+                    min(
+                        first_width,
+                        _MAX_LABEL_COLUMN_TWIPS,
+                        total_width - _MIN_TABLE_COLUMN_TWIPS,
+                    ),
+                )
+            else:
+                first_width = max(1, min(first_width, total_width - 1))
             return [first_width, total_width - first_width]
 
         if len(weights) * _MIN_TABLE_COLUMN_TWIPS > total_width:

--- a/pastemd/utils/docx_processor.py
+++ b/pastemd/utils/docx_processor.py
@@ -2,6 +2,7 @@
 
 import io
 import zipfile
+from typing import Optional
 from xml.sax.saxutils import quoteattr
 from xml.etree import ElementTree as ET
 
@@ -172,13 +173,11 @@ class DocxProcessor:
                 DocxProcessor._register_xml_namespaces(xml_namespaces)
                 root = ET.fromstring(document_xml)
 
-                modified_count = 0
-                for table in DocxProcessor._iter_top_level_tables(root):
-                    widths = DocxProcessor._suggest_table_column_widths(table, namespaces)
-                    if not widths:
-                        continue
-                    DocxProcessor._apply_table_column_widths(table, widths, namespaces)
-                    modified_count += 1
+                modified_count = DocxProcessor._auto_layout_tables_in_element(
+                    root,
+                    namespaces,
+                    _DOCX_TABLE_WIDTH_TWIPS,
+                )
 
                 if modified_count == 0:
                     log("No eligible DOCX table found for auto layout")
@@ -264,22 +263,71 @@ class DocxProcessor:
         return xml_text.encode("utf-8")
 
     @staticmethod
-    def _iter_top_level_tables(root: ET.Element) -> list[ET.Element]:
+    def _auto_layout_tables_in_element(
+        element: ET.Element,
+        namespaces: dict,
+        available_width: int,
+    ) -> int:
         w = f"{{{_WORD_NS}}}"
-        tables: list[ET.Element] = []
+        modified_count = 0
 
-        def walk(element: ET.Element, inside_cell: bool) -> None:
-            for child in list(element):
-                child_inside_cell = inside_cell or child.tag == f"{w}tc"
-                if child.tag == f"{w}tbl" and not inside_cell:
-                    tables.append(child)
-                walk(child, child_inside_cell)
+        for child in list(element):
+            if child.tag == f"{w}tbl":
+                modified_count += DocxProcessor._auto_layout_table_with_nested(
+                    child,
+                    namespaces,
+                    available_width,
+                )
+            else:
+                modified_count += DocxProcessor._auto_layout_tables_in_element(
+                    child,
+                    namespaces,
+                    available_width,
+                )
 
-        walk(root, False)
-        return tables
+        return modified_count
 
     @staticmethod
-    def _suggest_table_column_widths(table: ET.Element, namespaces: dict) -> list[int]:
+    def _auto_layout_table_with_nested(
+        table: ET.Element,
+        namespaces: dict,
+        available_width: int,
+    ) -> int:
+        modified_count = 0
+        widths = DocxProcessor._suggest_table_column_widths(
+            table,
+            namespaces,
+            available_width,
+        )
+
+        if widths:
+            DocxProcessor._apply_table_column_widths(table, widths, namespaces)
+            modified_count += 1
+        else:
+            widths = DocxProcessor._existing_table_column_widths(table, namespaces)
+
+        for row in table.findall("./w:tr", namespaces):
+            cells = row.findall("./w:tc", namespaces)
+            for index, cell in enumerate(cells):
+                cell_width = DocxProcessor._cell_width(cell, namespaces)
+                if cell_width is None and index < len(widths):
+                    cell_width = widths[index]
+                if cell_width is None:
+                    cell_width = available_width
+                modified_count += DocxProcessor._auto_layout_tables_in_element(
+                    cell,
+                    namespaces,
+                    cell_width,
+                )
+
+        return modified_count
+
+    @staticmethod
+    def _suggest_table_column_widths(
+        table: ET.Element,
+        namespaces: dict,
+        total_width: int,
+    ) -> list[int]:
         rows = table.findall("./w:tr", namespaces)
         if not rows:
             return []
@@ -287,6 +335,8 @@ class DocxProcessor:
         row_cells = [row.findall("./w:tc", namespaces) for row in rows]
         column_count = max((len(cells) for cells in row_cells), default=0)
         if column_count < 2:
+            return []
+        if total_width < column_count:
             return []
 
         if DocxProcessor._has_merged_cells(row_cells, namespaces):
@@ -301,7 +351,36 @@ class DocxProcessor:
         if not any(scores):
             return []
 
-        return DocxProcessor._column_widths_from_scores(scores, _DOCX_TABLE_WIDTH_TWIPS)
+        return DocxProcessor._column_widths_from_scores(scores, total_width)
+
+    @staticmethod
+    def _existing_table_column_widths(table: ET.Element, namespaces: dict) -> list[int]:
+        widths: list[int] = []
+        for grid_col in table.findall("./w:tblGrid/w:gridCol", namespaces):
+            width = DocxProcessor._parse_twips(grid_col.get(f"{{{_WORD_NS}}}w"))
+            if width is None:
+                return []
+            widths.append(width)
+        return widths
+
+    @staticmethod
+    def _cell_width(cell: ET.Element, namespaces: dict) -> Optional[int]:
+        tc_width = cell.find("./w:tcPr/w:tcW", namespaces)
+        if tc_width is None:
+            return None
+        if tc_width.get(f"{{{_WORD_NS}}}type") not in (None, "dxa"):
+            return None
+        return DocxProcessor._parse_twips(tc_width.get(f"{{{_WORD_NS}}}w"))
+
+    @staticmethod
+    def _parse_twips(value: Optional[str]) -> Optional[int]:
+        if value is None:
+            return None
+        try:
+            width = int(value)
+        except ValueError:
+            return None
+        return width if width > 0 else None
 
     @staticmethod
     def _direct_cell_text(cell: ET.Element) -> str:

--- a/pastemd/utils/docx_processor.py
+++ b/pastemd/utils/docx_processor.py
@@ -173,7 +173,7 @@ class DocxProcessor:
                 root = ET.fromstring(document_xml)
 
                 modified_count = 0
-                for table in root.findall(".//w:tbl", namespaces):
+                for table in DocxProcessor._iter_top_level_tables(root):
                     widths = DocxProcessor._suggest_table_column_widths(table, namespaces)
                     if not widths:
                         continue
@@ -264,6 +264,21 @@ class DocxProcessor:
         return xml_text.encode("utf-8")
 
     @staticmethod
+    def _iter_top_level_tables(root: ET.Element) -> list[ET.Element]:
+        w = f"{{{_WORD_NS}}}"
+        tables: list[ET.Element] = []
+
+        def walk(element: ET.Element, inside_cell: bool) -> None:
+            for child in list(element):
+                child_inside_cell = inside_cell or child.tag == f"{w}tc"
+                if child.tag == f"{w}tbl" and not inside_cell:
+                    tables.append(child)
+                walk(child, child_inside_cell)
+
+        walk(root, False)
+        return tables
+
+    @staticmethod
     def _suggest_table_column_widths(table: ET.Element, namespaces: dict) -> list[int]:
         rows = table.findall("./w:tr", namespaces)
         if not rows:
@@ -280,13 +295,28 @@ class DocxProcessor:
         scores = [0.0] * column_count
         for cells in row_cells:
             for index, cell in enumerate(cells):
-                text = "".join(node.text or "" for node in cell.findall(".//w:t", namespaces))
+                text = DocxProcessor._direct_cell_text(cell)
                 scores[index] = max(scores[index], DocxProcessor._visual_text_length(text))
 
         if not any(scores):
             return []
 
         return DocxProcessor._column_widths_from_scores(scores, _DOCX_TABLE_WIDTH_TWIPS)
+
+    @staticmethod
+    def _direct_cell_text(cell: ET.Element) -> str:
+        w = f"{{{_WORD_NS}}}"
+        parts: list[str] = []
+
+        def walk(element: ET.Element, inside_nested_table: bool) -> None:
+            for child in list(element):
+                child_inside_nested_table = inside_nested_table or child.tag == f"{w}tbl"
+                if child.tag == f"{w}t" and not child_inside_nested_table:
+                    parts.append(child.text or "")
+                walk(child, child_inside_nested_table)
+
+        walk(cell, False)
+        return "".join(parts)
 
     @staticmethod
     def _has_merged_cells(row_cells: list[list[ET.Element]], namespaces: dict) -> bool:

--- a/pastemd/utils/docx_processor.py
+++ b/pastemd/utils/docx_processor.py
@@ -8,6 +8,12 @@ from docx import Document
 from ..utils.logging import log
 
 
+_WORD_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+_DOCX_TABLE_WIDTH_TWIPS = 9360
+_MIN_TABLE_COLUMN_TWIPS = 900
+_MAX_LABEL_COLUMN_TWIPS = 2200
+
+
 class DocxProcessor:
     """DOCX 文档后处理器 - 用于修改已生成的 DOCX 文档样式"""
     
@@ -130,6 +136,185 @@ class DocxProcessor:
         except Exception as e:
             log(f"Failed to replace DOCX horizontal rules: {type(e).__name__}: {e}")
             return docx_bytes
+
+    @staticmethod
+    def auto_layout_tables(docx_bytes: bytes) -> bytes:
+        """
+        根据单元格文本长度调整 DOCX 普通表格列宽。
+
+        该处理主要改善「左侧短标签、右侧长内容」的两列表格，让 Word/WPS
+        打开后右侧内容列获得更多空间，减少不必要换行。
+        """
+        namespaces = {
+            "w": _WORD_NS,
+        }
+        for prefix, uri in namespaces.items():
+            ET.register_namespace(prefix, uri)
+
+        document_path = "word/document.xml"
+
+        try:
+            input_stream = io.BytesIO(docx_bytes)
+            output_stream = io.BytesIO()
+
+            with zipfile.ZipFile(input_stream, "r") as zin:
+                document_xml = zin.read(document_path)
+                root = ET.fromstring(document_xml)
+
+                modified_count = 0
+                for table in root.findall(".//w:tbl", namespaces):
+                    widths = DocxProcessor._suggest_table_column_widths(table, namespaces)
+                    if not widths:
+                        continue
+                    DocxProcessor._apply_table_column_widths(table, widths, namespaces)
+                    modified_count += 1
+
+                if modified_count == 0:
+                    log("No DOCX table found for auto layout")
+                    return docx_bytes
+
+                updated_document_xml = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+
+                with zipfile.ZipFile(output_stream, "w") as zout:
+                    for item in zin.infolist():
+                        data = updated_document_xml if item.filename == document_path else zin.read(item.filename)
+                        zout.writestr(item, data)
+
+            output_stream.seek(0)
+            log(f"Auto-layout applied to {modified_count} DOCX table(s)")
+            return output_stream.read()
+
+        except Exception as e:
+            log(f"Failed to auto-layout DOCX tables: {type(e).__name__}: {e}")
+            return docx_bytes
+
+    @staticmethod
+    def _suggest_table_column_widths(table: ET.Element, namespaces: dict) -> list[int]:
+        rows = table.findall("./w:tr", namespaces)
+        if not rows:
+            return []
+
+        row_cells = [row.findall("./w:tc", namespaces) for row in rows]
+        column_count = max((len(cells) for cells in row_cells), default=0)
+        if column_count < 2:
+            return []
+
+        if DocxProcessor._has_merged_cells(row_cells, namespaces):
+            return []
+
+        scores = [0.0] * column_count
+        for cells in row_cells:
+            for index, cell in enumerate(cells):
+                text = "".join(node.text or "" for node in cell.findall(".//w:t", namespaces))
+                scores[index] = max(scores[index], DocxProcessor._visual_text_length(text))
+
+        if not any(scores):
+            return []
+
+        return DocxProcessor._column_widths_from_scores(scores, _DOCX_TABLE_WIDTH_TWIPS)
+
+    @staticmethod
+    def _has_merged_cells(row_cells: list[list[ET.Element]], namespaces: dict) -> bool:
+        for cells in row_cells:
+            for cell in cells:
+                grid_span = cell.find("./w:tcPr/w:gridSpan", namespaces)
+                if grid_span is not None and grid_span.get(f"{{{_WORD_NS}}}val") not in (None, "1"):
+                    return True
+                if cell.find("./w:tcPr/w:vMerge", namespaces) is not None:
+                    return True
+        return False
+
+    @staticmethod
+    def _visual_text_length(text: str) -> float:
+        length = 0.0
+        for char in text:
+            if char.isspace():
+                length += 0.3
+            elif ord(char) > 127:
+                length += 2.0
+            else:
+                length += 1.0
+        return length
+
+    @staticmethod
+    def _column_widths_from_scores(scores: list[float], total_width: int) -> list[int]:
+        weights = [max(score, 4.0) for score in scores]
+
+        if len(weights) == 2 and weights[0] * 1.5 < weights[1]:
+            first_share = weights[0] / sum(weights)
+            first_width = int(total_width * max(0.14, min(first_share * 1.15, 0.24)))
+            first_width = max(_MIN_TABLE_COLUMN_TWIPS, min(first_width, _MAX_LABEL_COLUMN_TWIPS))
+            return [first_width, total_width - first_width]
+
+        if len(weights) * _MIN_TABLE_COLUMN_TWIPS > total_width:
+            base_width = max(1, total_width // (len(weights) * 2))
+        else:
+            base_width = _MIN_TABLE_COLUMN_TWIPS
+
+        widths = [base_width] * len(weights)
+        remaining_width = total_width - sum(widths)
+        if remaining_width < 0:
+            base_width = max(1, total_width // len(weights))
+            widths = [base_width] * len(weights)
+            remaining_width = total_width - sum(widths)
+
+        if remaining_width > 0:
+            weight_sum = sum(weights)
+            widths = [
+                width + int(remaining_width * weight / weight_sum)
+                for width, weight in zip(widths, weights)
+            ]
+
+        delta = total_width - sum(widths)
+        if delta:
+            index = max(range(len(widths)), key=lambda i: weights[i])
+            widths[index] += delta
+        return widths
+
+    @staticmethod
+    def _apply_table_column_widths(table: ET.Element, widths: list[int], namespaces: dict) -> None:
+        w = f"{{{_WORD_NS}}}"
+
+        tbl_pr = table.find("./w:tblPr", namespaces)
+        if tbl_pr is None:
+            tbl_pr = ET.Element(f"{w}tblPr")
+            table.insert(0, tbl_pr)
+
+        tbl_w = tbl_pr.find("./w:tblW", namespaces)
+        if tbl_w is None:
+            tbl_w = ET.SubElement(tbl_pr, f"{w}tblW")
+        tbl_w.set(f"{w}type", "dxa")
+        tbl_w.set(f"{w}w", str(sum(widths)))
+
+        tbl_layout = tbl_pr.find("./w:tblLayout", namespaces)
+        if tbl_layout is None:
+            tbl_layout = ET.SubElement(tbl_pr, f"{w}tblLayout")
+        tbl_layout.set(f"{w}type", "fixed")
+
+        for child in list(table):
+            if child.tag == f"{w}tblGrid":
+                table.remove(child)
+
+        tbl_grid = ET.Element(f"{w}tblGrid")
+        for width in widths:
+            grid_col = ET.SubElement(tbl_grid, f"{w}gridCol")
+            grid_col.set(f"{w}w", str(width))
+        table.insert(1 if table[0].tag == f"{w}tblPr" else 0, tbl_grid)
+
+        for row in table.findall("./w:tr", namespaces):
+            cells = row.findall("./w:tc", namespaces)
+            for index, cell in enumerate(cells):
+                if index >= len(widths):
+                    continue
+                tc_pr = cell.find("./w:tcPr", namespaces)
+                if tc_pr is None:
+                    tc_pr = ET.Element(f"{w}tcPr")
+                    cell.insert(0, tc_pr)
+                tc_w = tc_pr.find("./w:tcW", namespaces)
+                if tc_w is None:
+                    tc_w = ET.SubElement(tc_pr, f"{w}tcW")
+                tc_w.set(f"{w}type", "dxa")
+                tc_w.set(f"{w}w", str(widths[index]))
     
     @staticmethod
     def apply_custom_processing(
@@ -137,6 +322,7 @@ class DocxProcessor:
         disable_first_para_indent: bool = False,
         target_style: str = "Body Text",
         horizontal_rule_style: str = "default",
+        auto_layout_tables: bool = False,
     ) -> bytes:
         """
         对 DOCX 文档应用自定义后处理
@@ -146,6 +332,7 @@ class DocxProcessor:
             disable_first_para_indent: 是否禁用第一段特殊格式（替换 First Paragraph 样式）
             target_style: 目标样式名称
             horizontal_rule_style: 水平线样式，paragraph_border 时转为段落边框
+            auto_layout_tables: 是否自动调整普通表格列宽
             
         Returns:
             处理后的 DOCX 文件字节流
@@ -161,5 +348,8 @@ class DocxProcessor:
             docx_bytes = DocxProcessor.replace_horizontal_rules_with_paragraph_borders(
                 docx_bytes
             )
+
+        if auto_layout_tables:
+            docx_bytes = DocxProcessor.auto_layout_tables(docx_bytes)
         
         return docx_bytes

--- a/tests/test_docx_processor.py
+++ b/tests/test_docx_processor.py
@@ -1,0 +1,374 @@
+import io
+import re
+import zipfile
+from xml.etree import ElementTree as ET
+
+from docx import Document
+
+from pastemd.config.defaults import DEFAULT_CONFIG
+from pastemd.utils.docx_processor import DocxProcessor
+
+
+NAMESPACES = {
+    "w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+}
+
+
+def _make_label_content_docx() -> bytes:
+    doc = Document()
+    table = doc.add_table(rows=3, cols=2)
+    rows = [
+        ("要素", "内容"),
+        ("相关知识点\n(讲义原文)", "中位数：把一组数据按从小到大或大到小进行排列，位置居中的数值叫做中位数。"),
+        ("题目", "2019 年某县有 8 个大型建筑企业，这 8 个企业的员工人数分别为 600、632、710、740、760、800、850、910。"),
+    ]
+    for row, values in zip(table.rows, rows):
+        for cell, value in zip(row.cells, values):
+            cell.text = value
+
+    stream = io.BytesIO()
+    doc.save(stream)
+    return stream.getvalue()
+
+
+def _make_docx_table(rows: list[tuple[str, ...]]) -> bytes:
+    doc = Document()
+    table = doc.add_table(rows=len(rows), cols=len(rows[0]))
+    for row, values in zip(table.rows, rows):
+        for cell, value in zip(row.cells, values):
+            cell.text = value
+
+    stream = io.BytesIO()
+    doc.save(stream)
+    return stream.getvalue()
+
+
+def _table_grid_widths(docx_bytes: bytes) -> list[int]:
+    with zipfile.ZipFile(io.BytesIO(docx_bytes), "r") as archive:
+        document_xml = archive.read("word/document.xml")
+
+    root = ET.fromstring(document_xml)
+    grid_cols = root.findall(".//w:tbl[1]/w:tblGrid/w:gridCol", NAMESPACES)
+    return [
+        int(col.get(f"{{{NAMESPACES['w']}}}w"))
+        for col in grid_cols
+        if col.get(f"{{{NAMESPACES['w']}}}w")
+    ]
+
+
+def _document_xml(docx_bytes: bytes) -> str:
+    with zipfile.ZipFile(io.BytesIO(docx_bytes), "r") as archive:
+        return archive.read("word/document.xml").decode("utf-8")
+
+
+def _table_width_attrs(docx_bytes: bytes) -> tuple[str | None, str | None]:
+    with zipfile.ZipFile(io.BytesIO(docx_bytes), "r") as archive:
+        document_xml = archive.read("word/document.xml")
+
+    root = ET.fromstring(document_xml)
+    table_width = root.find(".//w:tbl[1]/w:tblPr/w:tblW", NAMESPACES)
+    assert table_width is not None
+    return (
+        table_width.get(f"{{{NAMESPACES['w']}}}type"),
+        table_width.get(f"{{{NAMESPACES['w']}}}w"),
+    )
+
+
+def _table_property_child_names(docx_bytes: bytes) -> list[str]:
+    with zipfile.ZipFile(io.BytesIO(docx_bytes), "r") as archive:
+        document_xml = archive.read("word/document.xml")
+
+    root = ET.fromstring(document_xml)
+    table_properties = root.find(".//w:tbl[1]/w:tblPr", NAMESPACES)
+    assert table_properties is not None
+    return [child.tag.rsplit("}", 1)[-1] for child in list(table_properties)]
+
+
+def _first_cell_property_child_names(docx_bytes: bytes) -> list[str]:
+    with zipfile.ZipFile(io.BytesIO(docx_bytes), "r") as archive:
+        document_xml = archive.read("word/document.xml")
+
+    root = ET.fromstring(document_xml)
+    cell_properties = root.find(".//w:tbl[1]/w:tr[1]/w:tc[1]/w:tcPr", NAMESPACES)
+    assert cell_properties is not None
+    return [child.tag.rsplit("}", 1)[-1] for child in list(cell_properties)]
+
+
+def _set_first_table_width(docx_bytes: bytes, width: int) -> bytes:
+    with zipfile.ZipFile(io.BytesIO(docx_bytes), "r") as archive:
+        document_xml = archive.read("word/document.xml")
+        root = ET.fromstring(document_xml)
+        table = root.find(".//w:tbl[1]", NAMESPACES)
+        assert table is not None
+
+        table_properties = table.find("./w:tblPr", NAMESPACES)
+        if table_properties is None:
+            table_properties = ET.Element(f"{{{NAMESPACES['w']}}}tblPr")
+            table.insert(0, table_properties)
+
+        table_width = table_properties.find("./w:tblW", NAMESPACES)
+        if table_width is None:
+            table_width = ET.SubElement(table_properties, f"{{{NAMESPACES['w']}}}tblW")
+        table_width.set(f"{{{NAMESPACES['w']}}}type", "dxa")
+        table_width.set(f"{{{NAMESPACES['w']}}}w", str(width))
+
+        grid_columns = table.findall("./w:tblGrid/w:gridCol", NAMESPACES)
+        assert grid_columns
+        base_width = width // len(grid_columns)
+        for index, column in enumerate(grid_columns):
+            column_width = base_width if index < len(grid_columns) - 1 else width - base_width * index
+            column.set(f"{{{NAMESPACES['w']}}}w", str(column_width))
+
+        for row in table.findall("./w:tr", NAMESPACES):
+            cells = row.findall("./w:tc", NAMESPACES)
+            for index, cell in enumerate(cells):
+                cell_properties = cell.find("./w:tcPr", NAMESPACES)
+                if cell_properties is None:
+                    cell_properties = ET.Element(f"{{{NAMESPACES['w']}}}tcPr")
+                    cell.insert(0, cell_properties)
+                cell_width = cell_properties.find("./w:tcW", NAMESPACES)
+                if cell_width is None:
+                    cell_width = ET.SubElement(cell_properties, f"{{{NAMESPACES['w']}}}tcW")
+                column_width = base_width if index < len(grid_columns) - 1 else width - base_width * index
+                cell_width.set(f"{{{NAMESPACES['w']}}}type", "dxa")
+                cell_width.set(f"{{{NAMESPACES['w']}}}w", str(column_width))
+
+        updated_document_xml = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+        output_stream = io.BytesIO()
+        with zipfile.ZipFile(output_stream, "w") as output:
+            for item in archive.infolist():
+                data = updated_document_xml if item.filename == "word/document.xml" else archive.read(item.filename)
+                output.writestr(item, data)
+        return output_stream.getvalue()
+
+
+def _set_first_table_percentage_width(docx_bytes: bytes, width: int) -> bytes:
+    with zipfile.ZipFile(io.BytesIO(docx_bytes), "r") as archive:
+        document_xml = archive.read("word/document.xml")
+        root = ET.fromstring(document_xml)
+        table_width = root.find(".//w:tbl[1]/w:tblPr/w:tblW", NAMESPACES)
+        assert table_width is not None
+        table_width.set(f"{{{NAMESPACES['w']}}}type", "pct")
+        table_width.set(f"{{{NAMESPACES['w']}}}w", str(width))
+
+        updated_document_xml = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+        output_stream = io.BytesIO()
+        with zipfile.ZipFile(output_stream, "w") as output:
+            for item in archive.infolist():
+                data = updated_document_xml if item.filename == "word/document.xml" else archive.read(item.filename)
+                output.writestr(item, data)
+        return output_stream.getvalue()
+
+
+def _remove_first_table_width(docx_bytes: bytes) -> bytes:
+    with zipfile.ZipFile(io.BytesIO(docx_bytes), "r") as archive:
+        document_xml = archive.read("word/document.xml")
+        root = ET.fromstring(document_xml)
+        table_properties = root.find(".//w:tbl[1]/w:tblPr", NAMESPACES)
+        assert table_properties is not None
+        table_width = table_properties.find("./w:tblW", NAMESPACES)
+        assert table_width is not None
+        table_properties.remove(table_width)
+
+        updated_document_xml = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+        output_stream = io.BytesIO()
+        with zipfile.ZipFile(output_stream, "w") as output:
+            for item in archive.infolist():
+                data = updated_document_xml if item.filename == "word/document.xml" else archive.read(item.filename)
+                output.writestr(item, data)
+        return output_stream.getvalue()
+
+
+def _remove_first_cell_width_and_add_shading(docx_bytes: bytes) -> bytes:
+    with zipfile.ZipFile(io.BytesIO(docx_bytes), "r") as archive:
+        document_xml = archive.read("word/document.xml")
+        root = ET.fromstring(document_xml)
+        cell_properties = root.find(".//w:tbl[1]/w:tr[1]/w:tc[1]/w:tcPr", NAMESPACES)
+        assert cell_properties is not None
+        cell_width = cell_properties.find("./w:tcW", NAMESPACES)
+        assert cell_width is not None
+        cell_properties.remove(cell_width)
+        shading = ET.SubElement(cell_properties, f"{{{NAMESPACES['w']}}}shd")
+        shading.set(f"{{{NAMESPACES['w']}}}fill", "FFFF00")
+
+        updated_document_xml = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+        output_stream = io.BytesIO()
+        with zipfile.ZipFile(output_stream, "w") as output:
+            for item in archive.infolist():
+                data = updated_document_xml if item.filename == "word/document.xml" else archive.read(item.filename)
+                output.writestr(item, data)
+        return output_stream.getvalue()
+
+
+def test_docx_auto_table_layout_is_disabled_by_default():
+    assert DEFAULT_CONFIG["docx_auto_table_layout"] is False
+
+
+def test_apply_custom_processing_keeps_table_widths_when_auto_layout_disabled():
+    docx_bytes = _make_label_content_docx()
+
+    processed = DocxProcessor.apply_custom_processing(
+        docx_bytes,
+        auto_layout_tables=False,
+    )
+
+    assert _table_grid_widths(processed) == _table_grid_widths(docx_bytes)
+
+
+def test_apply_custom_processing_can_auto_layout_label_content_tables():
+    docx_bytes = _make_label_content_docx()
+
+    processed = DocxProcessor.apply_custom_processing(
+        docx_bytes,
+        auto_layout_tables=True,
+    )
+
+    first_col, second_col = _table_grid_widths(processed)
+    assert first_col < second_col
+    assert first_col <= 2200
+
+
+def test_auto_layout_preserves_existing_fixed_table_width():
+    docx_bytes = _set_first_table_width(_make_label_content_docx(), 4000)
+
+    processed = DocxProcessor.apply_custom_processing(
+        docx_bytes,
+        auto_layout_tables=True,
+    )
+
+    assert sum(_table_grid_widths(processed)) == 4000
+
+
+def test_auto_layout_preserves_existing_percentage_table_width():
+    docx_bytes = _set_first_table_percentage_width(_make_label_content_docx(), 2500)
+
+    processed = DocxProcessor.apply_custom_processing(
+        docx_bytes,
+        auto_layout_tables=True,
+    )
+
+    assert _table_width_attrs(processed) == ("pct", "2500")
+    assert sum(_table_grid_widths(processed)) == 4680
+
+
+def test_auto_layout_inserts_table_layout_before_table_look():
+    docx_bytes = _make_label_content_docx()
+
+    processed = DocxProcessor.apply_custom_processing(
+        docx_bytes,
+        auto_layout_tables=True,
+    )
+
+    child_names = _table_property_child_names(processed)
+    assert child_names.index("tblLayout") < child_names.index("tblLook")
+
+
+def test_auto_layout_inserts_missing_table_width_before_table_look():
+    docx_bytes = _remove_first_table_width(_make_label_content_docx())
+
+    processed = DocxProcessor.apply_custom_processing(
+        docx_bytes,
+        auto_layout_tables=True,
+    )
+
+    child_names = _table_property_child_names(processed)
+    assert child_names.index("tblW") < child_names.index("tblLook")
+    assert child_names.index("tblLayout") < child_names.index("tblLook")
+
+
+def test_auto_layout_inserts_missing_cell_width_before_cell_shading():
+    docx_bytes = _remove_first_cell_width_and_add_shading(_make_label_content_docx())
+
+    processed = DocxProcessor.apply_custom_processing(
+        docx_bytes,
+        auto_layout_tables=True,
+    )
+
+    child_names = _first_cell_property_child_names(processed)
+    assert child_names.index("tcW") < child_names.index("shd")
+
+
+def test_auto_layout_keeps_wide_table_column_widths_positive():
+    widths = DocxProcessor._column_widths_from_scores([1.0] * 12, 9360)
+
+    assert len(widths) == 12
+    assert sum(widths) == 9360
+    assert all(width > 0 for width in widths)
+
+
+def test_auto_layout_preserves_ignorable_namespace_declarations():
+    docx_bytes = _make_label_content_docx()
+
+    processed = DocxProcessor.apply_custom_processing(
+        docx_bytes,
+        auto_layout_tables=True,
+    )
+
+    xml = _document_xml(processed)
+    document_start_match = re.search(r"<w:document\b[^>]*>", xml)
+    assert document_start_match is not None
+    document_start = document_start_match.group(0)
+    ignorable_match = re.search(r"(?:mc|ns\d+):Ignorable=\"([^\"]+)\"", document_start)
+
+    assert ignorable_match is not None
+    for prefix in ignorable_match.group(1).split():
+        assert f"xmlns:{prefix}=" in document_start
+
+
+def test_auto_layout_keeps_quiz_explanation_column_readable():
+    docx_bytes = _make_docx_table([
+        ("模块", "题型", "题干", "选项", "答案", "解析"),
+        (
+            "描述统计",
+            "单选题",
+            "某班 8 名学生的成绩分别为 60、62、71、74、76、80、85、91，这组数据的中位数是（ ）分。",
+            "A. 74 B. 76 C. 75 D. 80",
+            "C",
+            "数据已经从小到大排列，数量为 8，是偶数，因此中位数为第 4 个数和第 5 个数的平均值，即 (74+76)/2=75。",
+        ),
+        (
+            "概率",
+            "单选题",
+            "一个袋子中有 3 个红球、2 个白球、5 个黑球，随机摸出一个球，摸到红球的概率是（ ）。",
+            "A. 1/5 B. 3/10 C. 1/2 D. 3/5",
+            "B",
+            "总球数为 10，红球数为 3，因此概率为 3/10。",
+        ),
+        (
+            "几何",
+            "多选题",
+            "下列说法正确的是（ ）。",
+            "A. 正方形是矩形 B. 矩形一定是正方形 C. 平行四边形对边相等 D. 菱形四条边相等",
+            "ACD",
+            "正方形属于特殊矩形；矩形不一定四边相等；平行四边形对边相等；菱形四条边相等。",
+        ),
+    ])
+
+    processed = DocxProcessor.apply_custom_processing(
+        docx_bytes,
+        auto_layout_tables=True,
+    )
+
+    widths = _table_grid_widths(processed)
+    assert widths[5] >= 2200
+    assert widths[5] >= widths[3]
+
+
+def test_auto_layout_gives_long_note_column_space_in_very_wide_tables():
+    docx_bytes = _make_docx_table([
+        ("日期", "渠道", "曝光", "点击", "CTR", "注册", "CVR", "付费", "ARPU", "GMV", "ROI", "备注"),
+        ("2026-06-01", "Search", "120,000", "8,420", "7.02%", "1,260", "14.96%", "168", "39.8", "6,686.4", "1.82", "搜索渠道流量稳定，点击率较上周略有提升。"),
+        ("2026-06-02", "Feed", "96,500", "5,930", "6.15%", "842", "14.20%", "101", "36.1", "3,646.1", "1.34", "信息流素材更换后点击率提升，但付费转化仍偏低。"),
+        ("2026-06-03", "Referral", "18,240", "2,108", "11.56%", "690", "32.73%", "122", "42.7", "5,209.4", "3.91", "推荐渠道量级较小但质量较高。"),
+        ("2026-06-04", "Email", "42,300", "3,012", "7.12%", "510", "16.93%", "74", "31.5", "2,331.0", "1.76", "邮件召回用户对促销活动响应明显。"),
+    ])
+
+    processed = DocxProcessor.apply_custom_processing(
+        docx_bytes,
+        auto_layout_tables=True,
+    )
+
+    widths = _table_grid_widths(processed)
+    assert widths[-1] >= 1600
+    assert widths[-1] > widths[0]
+    assert all(width > 0 for width in widths)


### PR DESCRIPTION
## 概要

增加一个实验性的 DOCX 表格自动排版选项，用于改善 Word/WPS 中 Markdown 表格的列宽显示效果。

该功能会在 DOCX 生成后，根据表格内容长度重新分配普通表格的列宽。主要用于改善左侧短标签、右侧长内容这类表格的显示效果。功能默认关闭，需要用户在实验性功能中手动开启。

## 改动内容

- 在 `DocxProcessor` 中增加 DOCX 表格列宽后处理
- 接入 Markdown → DOCX 和 HTML → DOCX 生成流程
- 新增配置项 `docx_auto_table_layout`，默认值为 `false`
- 在“实验性功能”设置页增加开关
- 补充 zh-CN、en-US、ja-JP 三种语言文案

## 行为说明

开启后，PasteMD 会重写生成 DOCX 中的表格宽度信息：

- `w:tblW`
- `w:tblLayout`
- `w:tblGrid`
- `w:tcW`

为了避免破坏复杂结构，包含合并单元格的表格会被跳过。

## 验证

已使用多类 DOCX 表格场景进行手动验证，包括：

- 两列“标签 / 内容”表格
- 多列指标表格
- 包含长文本末列的宽表格
- 选择题解析类表格