### PR TITLE
[codex] fix(markdown): preserve copied code newlines

### DIFF
--- a/pastemd/service/preprocessor/markdown.py
+++ b/pastemd/service/preprocessor/markdown.py
@@ -1,7 +1,7 @@
 """Markdown content preprocessor."""
 
 from .base import BasePreprocessor
-from ...utils.md_normalizer import normalize_markdown
+from ...utils.md_normalizer import fence_plain_text_code, normalize_markdown
 from ...utils.latex import convert_latex_delimiters
 from ...utils.logging import log
 
@@ -26,6 +26,8 @@ class MarkdownPreprocessor(BasePreprocessor):
             预处理后的 Markdown 文本
         """
         log("Preprocessing Markdown content")
+
+        markdown = fence_plain_text_code(markdown)
 
         # 1. 标准化 Markdown
         if config.get("normalize_markdown", True):

--- a/pastemd/utils/md_normalizer.py
+++ b/pastemd/utils/md_normalizer.py
@@ -3,6 +3,41 @@
 import re
 
 
+def fence_plain_text_code(md_text: str) -> str:
+    """Wrap obvious copied code snippets so Pandoc preserves line breaks."""
+    text = md_text.replace('\r\n', '\n').replace('\r', '\n')
+    stripped = text.strip('\n')
+    lines = stripped.split('\n')
+    non_empty = [line for line in lines if line.strip()]
+    if len(non_empty) < 2 or any(line.lstrip().startswith('```') for line in lines):
+        return md_text
+
+    markdown_markers = (
+        r'^#{1,6}\s+',
+        r'^>\s?',
+        r'^\s*[-*+]\s+',
+        r'^\s*\d+\.\s+',
+        r'^\s*\|.*\|\s*$',
+    )
+    if any(any(re.match(pattern, line) for pattern in markdown_markers) for line in non_empty):
+        return md_text
+
+    # ponytail: heuristic only catches obvious code; use clipboard metadata if false positives matter.
+    keyword = re.compile(
+        r'^\s*(from|import|def|class|if|elif|else|for|while|try|except|with|return|'
+        r'const|let|var|function|export|public|private|protected|static|package|using|namespace|#include)\b'
+    )
+    signal_lines = sum(
+        bool(line[:1] in (' ', '\t') or keyword.match(line) or re.search(r'[{}();=<>[\]]', line))
+        for line in non_empty
+    )
+    if signal_lines < max(2, len(non_empty) // 2):
+        return md_text
+
+    fenced = f"```\n{stripped}\n```"
+    return fenced.replace('\n', '\r\n') if '\r\n' in md_text else fenced
+
+
 def normalize_markdown(md_text: str) -> str:
     """
     规范化 Markdown 文本格式，确保元素之间有适当的空行
@@ -179,4 +214,3 @@ def _should_add_blank_after(current_type: str, index: int, lines: list) -> bool:
         return True
     
     return False
-

--- a/tests/test_md_normalizer.py
+++ b/tests/test_md_normalizer.py
@@ -1,0 +1,19 @@
+from pastemd.utils.md_normalizer import fence_plain_text_code
+
+
+def test_fence_plain_text_code_wraps_copied_code_snippet():
+    text = "function greet(name) {\n  return `hello ${name}`;\n}"
+
+    assert fence_plain_text_code(text) == "```\nfunction greet(name) {\n  return `hello ${name}`;\n}\n```"
+
+
+def test_fence_plain_text_code_leaves_normal_markdown_alone():
+    text = "# Title\n\nA normal paragraph\n\n- item"
+
+    assert fence_plain_text_code(text) == text
+
+
+def test_fence_plain_text_code_leaves_existing_fences_alone():
+    text = "```js\nconsole.log('ok')\n```"
+
+    assert fence_plain_text_code(text) == text


### PR DESCRIPTION
## Summary
- wrap obvious multiline plain-text code snippets in fenced code blocks before Markdown normalization
- keep existing fenced Markdown and common Markdown blocks unchanged
- add tests for copied code, normal Markdown, and existing fences

Fixes #45.

## Validation
- `/tmp/pastemd-pr-venv/bin/python -m pytest tests/`
- `git diff --check`