### PR TITLE
docs: 修复 Star 历史图表失效问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ pyinstaller --clean -F -w -n PasteMD
      alt="喜欢你"
      width="150">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=RICHQAQ/PasteMD&type=date&legend=top-left)](https://www.star-history.com/#RICHQAQ/PasteMD&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=RICHQAQ/PasteMD&type=date&legend=top-left)](https://star-history.dera.page/#RICHQAQ/PasteMD&type=date&legend=top-left)
 
 ## 🍵支持与打赏
 

--- a/docs/md/README.en.md
+++ b/docs/md/README.en.md
@@ -452,7 +452,7 @@ Thanks for every star — please share PasteMD with more users. I am aiming for 
      alt="like you"
      width="150">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=RICHQAQ/PasteMD&type=date&legend=top-left)](https://www.star-history.com/#RICHQAQ/PasteMD&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=RICHQAQ/PasteMD&type=date&legend=top-left)](https://star-history.dera.page/#RICHQAQ/PasteMD&type=date&legend=top-left)
 
 ## ☕ Support & Donation
 

--- a/docs/md/README.ja.md
+++ b/docs/md/README.ja.md
@@ -454,7 +454,7 @@ Star してくれたみなさん、いつもありがとうございます！も
      alt="likeyou"
      width="150">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=RICHQAQ/PasteMD&type=date&legend=top-left)](https://www.star-history.com/#RICHQAQ/PasteMD&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=RICHQAQ/PasteMD&type=date&legend=top-left)](https://star-history.dera.page/#RICHQAQ/PasteMD&type=date&legend=top-left)
 
 ## 🍵 サポート/投げ銭
 


### PR DESCRIPTION
由于 GitHub API 的限制，README 中的 Star 历史图表目前无法正常显示。本次修改将图表链接切换到稳定的数据源，恢复图表展示，并同步更新了 README、英文版及日文版文档。